### PR TITLE
Expand Getting Started (add JS) and Add External Resources

### DIFF
--- a/docs/quickstart/_category_.json
+++ b/docs/quickstart/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Quick Start",
+    "position": 1,
+    "link": {
+        "type": "generated-index",
+        "description": "A set of tools to get started building on Nifty."
+    }
+}

--- a/docs/quickstart/cli.mdx
+++ b/docs/quickstart/cli.mdx
@@ -1,10 +1,11 @@
 ---
-sidebar_position: 3
+title: Getting Started - CLI
+sidebar_label: Nifty CLI
+pagination_prev: null
+pagination_next: null
 ---
 
-# Quickstart
-
-## CLI
+# Nifty CLI
 
 You can install the bundled Nifty CLI to start playing around with Nift assets.
 
@@ -193,78 +194,4 @@ To print a specific field, you can use the `--field` option:
 
 ```bash
 nifty decode 5to4wpbDE1KkBHKgFYFVEBz3UBFRqpovSgQYJzSbTe85 --field name
-```
-
-## JS Client
-
-You can also use the Nifty JS client to interact with Nifty Assets. First, generate it with `pnpm` from the root directory of the `nifty-asset` respository:
-
-Build the programs:
-
-```bash
-pnpm programs:build
-```
-
-Generate the JS and Rust clients:
-
-```bash
-pnpm generate:clients
-```
-
-or generate both the clients and the IDL:
-
-```bash
-pnpm generate
-```
-
-This will generate the JS client in the `clients/js` directory. You can use it to interact with the Nifty Asset program.
-
-In this example we use the "mint" helper function to allocate a new asset with some extensions, write the extension data and then
-create the asset.
-
-```typescript
-import { Connection, PublicKey } from '@solana/web3.js';
-import {
-  Asset,
-  Discriminator,
-  ExtensionType,
-  Standard,
-  State,
-  attributes,
-  fetchAsset,
-  links,
-  niftyAsset,
-  mint,
-} from '@nifty-oss/asset';
-import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
-
-const umi = (await createUmi()).use(niftyAsset());
-const connection = new Connection(umi);
-
-const asset = generateSigner(umi);
-const holder = generateSigner(umi);
-
-await mint(umi, {
-asset,
-holder: holder.publicKey,
-payer: umi.identity,
-name: 'Digital Asset',
-extensions: [
-    attributes([
-    { traitType: 'Attributes Count', value: '2' },
-    { traitType: 'Type', value: 'Dark' },
-    { traitType: 'Clothes', value: 'Purple Shirt' },
-    { traitType: 'Ears', value: 'None' },
-    { traitType: 'Mouth', value: 'None' },
-    { traitType: 'Eyes', value: 'None' },
-    { traitType: 'Hat', value: 'Blue Cap' },
-    ]),
-    links([
-    {
-        name: 'metadata',
-        uri: 'https://arweave.net/ebBV1qEYt65AKmM2J5wH_Vg-gjBa9YcwSYWFVt0rw9w',
-    },
-    ]),
-],
-}).sendAndConfirm(umi);
 ```

--- a/docs/quickstart/javascript.mdx
+++ b/docs/quickstart/javascript.mdx
@@ -1,0 +1,176 @@
+---
+title: Getting Started - JavaScript
+sidebar_label: JavaScript Client
+pagination_prev: null
+pagination_next: null
+---
+
+# Getting Started
+
+The Nifty Asset JS Client is a JavaScript client that provides a set of methods for interacting with the Nifty Asset program on the Solana Virtual Machine. This guide will help you get started with the Nifty Asset JS Client and show you how to use it with the Umi framework.
+
+## Requirements
+
+- [Node.js](https://nodejs.org/) version 18 or higher
+- [NPM](https://www.npmjs.com/) or other package manager (e.g., Yarn, PNPM)
+- [TypeScript](https://www.typescriptlang.org/) version 4.0 or higher installed
+- [Solana CLI](https://docs.solanalabs.com/cli) installed (for local development)
+
+## Umi
+
+The Nifty Asset JS Client is built to work with the Umi framework. [Umi](https://github.com/metaplex-foundation/umi) is a lightweight JavaScript framework that is used to build Solana clients. Umi was built and is maintained by the Metaplex Foundation. The Nifty Asset JS Client is an Umi plugin that provides a set of methods for interacting with the Nifty Asset program.
+
+### Required Dependencies
+
+To get started you will need to install the following libraries:
+
+- `@metaplex-foundation/umi`: The core Umi framework [npmjs.com](https://www.npmjs.com/package/@metaplex-foundation/umi)
+- `@metaplex-foundation/umi-bundle-defaults`: Default plug-ins bundle for Umi [npmjs.com](https://www.npmjs.com/package/@metaplex-foundation/umi-bundle-defaults)
+- `@nifty-oss/asset`: The Nifty Asset JS Client [npmjs.com](https://www.npmjs.com/package/@nifty-oss/asset)
+
+Add these dependencies to your project by running the following command:
+
+```bash
+npm install \
+  @metaplex-foundation/umi \
+  @metaplex-foundation/umi-bundle-defaults \
+  @nifty-oss/asset
+```
+
+### Umi Configuration
+
+To use the Nifty Asset JS Client, you will need to configure Umi to use the network of your choice (e.g., Solana Mainnet, Devnet, Testnet, or Local) and the Nifty Asset plugin. Create an instance of *Umi* with the `createUmi` method, and pass in the network URL:
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com');
+```
+
+To configure Umi on other networks, simply replace the URL in the `createUmi` method with the RPC endpoint of your choice.
+
+## RPC Endpoints
+
+Here is a list of public RPC endpoints for Solana. Though public endpoints may be suitable for light use and testing, or production applications, we reccomend using an endpoint from a third party provider (e.g., [QuickNode](https://www.quicknode.com/chains/sol), [Helius](https://helius.xyz/)).
+
+| Network | URL |
+| --- | --- |
+| Mainnet | https://api.mainnet-beta.solana.com |
+| Devnet | https://api.devnet.solana.com |
+| Testnet | https://api.testnet.solana.com |
+| Localnet<br/>_(default)_ | http://127.0.0.1:8899 |
+
+_Replace the URL in your `createUmi` method with the network of your choice._
+
+### Local Use
+
+To interact with the Nifty Asset program on a local Solana network, you will need to deploy the program to your local network. You can deploy the program when you initiate your test validator, but you must first write the program data to a file. You can do this by running the following command:
+
+```sh
+solana program dump AssetGtQBTSgm5s91d1RAQod5JmaZiJDxqsgtqrZud73 nifty_asset.so -um
+```
+
+This command will write the current program data from mainnet (specified by use of the `-um` flag) to a file named `nifty_asset.so` in the current directory. You can then deploy the program to your local network by running the following command:
+
+```sh
+solana-test-validator -r --bpf-program AssetGtQBTSgm5s91d1RAQod5JmaZiJDxqsgtqrZud73 nifty_asset.so
+```
+
+This command will start a local Solana validator with the Nifty Asset program deployed. If set up correctly, you should be able to see the Nifty Asset program on your [local Solana Explorer](https://explorer.solana.com/address/AssetGtQBTSgm5s91d1RAQod5JmaZiJDxqsgtqrZud73?cluster=custom&customUrl=http%3A%2F%2Flocalhost%3A8899) or by verifying the program with the Solana CLI:
+
+```sh
+solana program show AssetGtQBTSgm5s91d1RAQod5JmaZiJDxqsgtqrZud73 -ul
+```
+
+## Use Nifty Asset JS Client
+
+To use the Nifty Asset JS Client, you will need to import the client and add it to your Umi instance using the `.use()` this this:
+
+```typescript
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { niftyAsset } from '@nifty-oss/asset';
+
+const umi = createUmi('https://api.mainnet-beta.solana.com').use(niftyAsset());
+```
+
+The `.use()` method registers the Nifty Asset plugin with the Umi instance, enabling access to the Nifty Asset methods.
+
+You are all set and ready to start using the Nifty Asset JS Client with Umi. We will use this same structure throughout the documentation to demonstrate how to use the Nifty Asset JS Client with Umi, so take a moment to familiarize yourself with this setup. If you have any questions, please reach out to the Nifty Asset team on [Discord](https://discord.gg/uTMaCT7x9D).
+
+## Example Use
+
+Below is an example function that demonstrates how to use the `mint` method to create a new digital asset:
+
+```typescript
+import { niftyAsset, mint, Standard, attributes } from '@nifty-oss/asset';
+import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
+import { TransactionBuilderSendAndConfirmOptions, generateSigner, keypairIdentity, sol } from '@metaplex-foundation/umi';
+
+const umi = createUmi('http://127.0.0.1:8899', { commitment: 'processed' }).use(niftyAsset());
+
+async function mintAsset() {
+    const creator = generateSigner(umi);
+    const owner = generateSigner(umi);
+    const asset = generateSigner(umi);
+    umi.use(keypairIdentity(creator));
+
+    await umi.rpc.airdrop(creator.publicKey, sol(100));
+
+    await mint(umi, {
+        asset,
+        owner: owner.publicKey,
+        authority: creator.publicKey,
+        payer: umi.identity,
+        name: 'Example NFT',
+        standard: Standard.NonFungible,
+        mutable: false,
+        extensions: [
+            attributes([{ name: 'head', value: 'hat' }]),
+        ]
+    }).sendAndConfirm(umi);
+}
+
+mintAsset();
+```
+
+## Source Code
+
+The source code for the Nifty Asset JS Client is available on [GitHub](https://github.com/nifty-oss/asset/tree/main/clients/js/asset).
+
+### Contribute 
+To make contributions, please check out the [Contributing Guide](https://github.com/nifty-oss/asset/blob/main/clients/js/asset/CONTRIBUTING.md).
+
+### Build from Source
+To build the client from source, follow the following steps: 
+
+Clone the repository:
+
+```bash
+git clone https://github.com/nifty-oss/asset && cd asset
+```
+
+Install the dependencies:
+
+```bash
+pnpm install
+```
+
+Build the programs:
+
+```bash
+pnpm programs:build
+```
+
+Generate the JS and Rust clients:
+
+```bash
+pnpm generate:clients
+```
+
+or generate both the clients and the IDL:
+
+```bash
+pnpm generate
+```
+
+This will generate the JS client in the `clients/js` directory. You can use it to interact with the Nifty Asset program.

--- a/docs/resources.mdx
+++ b/docs/resources.mdx
@@ -1,0 +1,17 @@
+---
+title: External Resources
+sidebar_label: External Resources
+pagination_prev: null
+pagination_next: null
+---
+
+# External Resources
+
+## Guides and Walkthroughs
+
+- [What is Nifty Asset Standard and How to Mint Your First Nifty Asset?](https://www.quicknode.com/guides/solana-development/nfts/nifty/)
+
+## Open Source Implementations
+
+- [LibrePlex Fair Launch Hybrid (Anchor)](https://github.com/LibrePlex/libreplex_fair_launch_generators/tree/main/programs/libreplex_nifty_hybrid)
+- [Epochs: On-chain Asset Generation (Anchor)](https://github.com/amilz/epochs/tree/main/programs/epochs)


### PR DESCRIPTION
This PR does 2 thing: 


1. **QuickStart:**  migrates existing quick start page into a toggle that includes `CLI` and `JavaScript`. JavaScript includes setup for umi and local use, example use, and how to build locally. This seemed a little cleaner than trying to force a JavaScript section into the instructions or somewhere else...but I'm happy to migrate it. LMK what you think.


2. **External Resources:** creates a page for external resources. I started with guides/repos I know, but feel free to lmk if you want to change this.

![image](https://github.com/nifty-oss/website/assets/85324096/307eeada-ca84-4821-8084-b4feec834bad)
